### PR TITLE
Add hashpoolpro.com

### DIFF
--- a/pools-v2.json
+++ b/pools-v2.json
@@ -1383,5 +1383,17 @@
     ],
     "tags": ["mining-dutch"],
     "link": "https://www.mining-dutch.nl/"
+  },
+  {
+    "id": 1017,
+    "name": "HashPoolPro",
+    "addresses": [
+      "bc1q5njwge8xhxn9z7sc23t2yv9yhjtemcau467ewa",
+      "bc1qmnht05ufm27dzg2kxn38h0eel84ae4h4lhkzxa",
+      "bc1q753jjpxjpqyztyry9pwdlfgr385l7dr6dpnhzk",
+      "bc1qsskm85t36pd0c7v3cdva0uhwuv5wwuz6nl93xf"
+    ],
+    "tags": ["/hashpoolpro/", "/hashpoolpro.com/"],
+    "link": "https://hashpoolpro.com/"
   }
 ]


### PR DESCRIPTION
Hello,
I would like to open this pull request to add the mining pool **hashpoolpro** into the `pools-v2.json` configuration file.

Example block hashpoolpro.com:
https://mempool.fractalbitcoin.io/block/0000000000000000887407f81010fcc7661036c11e4ec2e4a6af51184daf9a9c

Example block hashpoolpro:
https://mempool.fractalbitcoin.io/block/000000000000000067e3aec5e6608a1ca6e4148fbf8e815a63bbbebd8d89b017

Thank you for reviewing this contribution!