### PR TITLE
Add Solo256 mining pool

### DIFF
--- a/pools-v2.json
+++ b/pools-v2.json
@@ -1395,5 +1395,12 @@
     ],
     "tags": ["/hashpoolpro/", "/hashpoolpro.com/"],
     "link": "https://hashpoolpro.com/"
+  },
+  {
+    "id": 1018,
+    "name": "Solo256",
+    "addresses": [],
+    "tags": ["solo256.com"],
+    "link": "https://solo256.com/"
   }
 ]


### PR DESCRIPTION
Add Solo256 mining pool metadata.

Pool name: Solo256
Slug: solo256
Website: https://solo256.com/
Coinbase tag regex: solo256\.com
Logo file: solo256.svg

Example Fractal block:
https://mempool.fractalbitcoin.io/zh/block/000000000000000095136b68211b748d0fd1cbeb022f14ba6382c11bf2d60004

Block height: 1906264
Coinbase txid: 71d77bd7843b560eb856b22a30628801963a5d0002fc4df5d5537095d1fd3b17
Coinbase ASCII includes: ckpool / solo256.com

Current explorer pool is Unknown; this PR maps the existing Solo256 coinbase tag to the Solo256 mining pool.